### PR TITLE
Remove git{config,ignore,attributes}-mode

### DIFF
--- a/init.el
+++ b/init.el
@@ -388,9 +388,6 @@
 ;; Language
 ;; ---------------------------------------------------------------------
 
-(leaf gitconfig-mode :ensure t)
-(leaf gitignore-mode :ensure t)
-(leaf gitattributes-mode :ensure t)
 (leaf ssh-config-mode :ensure t)
 
 ;; ShellScript


### PR DESCRIPTION
This removes gitconfig-mode, gitignore-mode and gitattributes-mode because they are not available.

```
Contacting host: orgmode.org:443
Contacting host: elpa.gnu.org:443
Package refresh done
Contacting host: orgmode.org:443
Package refresh done
Warning (leaf): In `gitconfig-mode' block at `/home/emacs/.emacs.d/init.el', failed to :package of `gitconfig-mode'.  Error msg: Package `gitconfig-mode-' is unavailable
Contacting host: orgmode.org:443
Package refresh done
Contacting host: orgmode.org:443
Package refresh done
Warning (leaf): In `gitignore-mode' block at `/home/emacs/.emacs.d/init.el', failed to :package of `gitignore-mode'.  Error msg: Package `gitignore-mode-' is unavailable
Contacting host: orgmode.org:443
Contacting host: elpa.gnu.org:443
Package refresh done
Contacting host: elpa.gnu.org:443
Package refresh done
Warning (leaf): In `gitattributes-mode' block at `/home/emacs/.emacs.d/init.el', failed to :package of `gitattributes-mode'.  Error msg: Package `gitattributes-mode-' is unavailable
```
